### PR TITLE
feat: add land-use seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Create a new migration when needed:
 alembic revision --autogenerate -m "describe change"
 ```
 
+## Seed Data
+
+Seed controlled demo land-use data:
+
+```bash
+uv run python scripts/seed_land_use.py
+```
+
 ## Demo Flow
 
 Assuming the app is running on `http://127.0.0.1:8000`.

--- a/scripts/seed_land_use.py
+++ b/scripts/seed_land_use.py
@@ -1,0 +1,16 @@
+from geoinsight_api.db.session import SessionLocal
+from geoinsight_api.seeds.land_use import seed_land_use_data
+
+
+def main() -> None:
+    session = SessionLocal()
+
+    try:
+        layer = seed_land_use_data(session)
+        print(f"Seeded land-use layer: {layer.id}")
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/geoinsight_api/seeds/land_use.py
+++ b/src/geoinsight_api/seeds/land_use.py
@@ -1,0 +1,96 @@
+from geoalchemy2.shape import from_shape
+from shapely.geometry import MultiPolygon, Polygon
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from geoinsight_api.db.models.vector_feature import VectorFeature
+from geoinsight_api.db.models.vector_layer import VectorLayer
+
+LAND_USE_LAYER_NAME = "Demo Land Use"
+LAND_USE_LAYER_TYPE = "land_use"
+LAND_USE_SOURCE = "seed"
+
+
+def _multipolygon_from_bounds(
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+) -> MultiPolygon:
+    polygon = Polygon(
+        [
+            (min_x, min_y),
+            (max_x, min_y),
+            (max_x, max_y),
+            (min_x, max_y),
+            (min_x, min_y),
+        ]
+    )
+
+    return MultiPolygon([polygon])
+
+
+LAND_USE_FEATURES = [
+    {
+        "class": "forest",
+        "geometry": _multipolygon_from_bounds(44.500, 40.100, 44.505, 40.110),
+    },
+    {
+        "class": "agriculture",
+        "geometry": _multipolygon_from_bounds(44.505, 40.100, 44.510, 40.105),
+    },
+    {
+        "class": "urban",
+        "geometry": _multipolygon_from_bounds(44.505, 40.105, 44.510, 40.110),
+    },
+    {
+        "class": "water",
+        "geometry": _multipolygon_from_bounds(44.502, 40.102, 44.508, 40.108),
+    },
+    {
+        "class": "grassland",
+        "geometry": _multipolygon_from_bounds(44.510, 40.100, 44.515, 40.110),
+    },
+]
+
+
+def seed_land_use_data(session: Session) -> VectorLayer:
+    layer = session.scalar(
+        select(VectorLayer).where(
+            VectorLayer.name == LAND_USE_LAYER_NAME,
+            VectorLayer.layer_type == LAND_USE_LAYER_TYPE,
+            VectorLayer.source == LAND_USE_SOURCE,
+        )
+    )
+
+    if layer is None:
+        layer = VectorLayer(
+            name=LAND_USE_LAYER_NAME,
+            description="Controlled demo land-use layer for spatial analysis tests",
+            layer_type=LAND_USE_LAYER_TYPE,
+            source=LAND_USE_SOURCE,
+            srid=4326,
+            properties_schema={"class": "string"},
+        )
+        session.add(layer)
+        session.flush()
+    else:
+        layer.description = "Controlled demo land-use layer for spatial analysis tests"
+        layer.srid = 4326
+        layer.properties_schema = {"class": "string"}
+        session.flush()
+
+    session.execute(delete(VectorFeature).where(VectorFeature.layer_id == layer.id))
+
+    for feature_data in LAND_USE_FEATURES:
+        feature = VectorFeature(
+            layer_id=layer.id,
+            geometry=from_shape(feature_data["geometry"], srid=4326),
+            properties={"class": feature_data["class"]},
+        )
+        session.add(feature)
+
+    session.commit()
+    session.refresh(layer)
+
+    return layer

--- a/src/geoinsight_api/seeds/land_use.py
+++ b/src/geoinsight_api/seeds/land_use.py
@@ -90,7 +90,6 @@ def seed_land_use_data(session: Session) -> VectorLayer:
         )
         session.add(feature)
 
-    session.commit()
-    session.refresh(layer)
+    session.flush()
 
     return layer

--- a/tests/test_seed_land_use.py
+++ b/tests/test_seed_land_use.py
@@ -1,0 +1,130 @@
+from geoalchemy2.shape import from_shape
+from shapely.geometry import MultiPolygon, Polygon
+from sqlalchemy import func, select
+
+from geoinsight_api.db.models.aoi import AOI
+from geoinsight_api.db.models.project import Project
+from geoinsight_api.db.models.vector_feature import VectorFeature
+from geoinsight_api.db.models.vector_layer import VectorLayer
+from geoinsight_api.seeds.land_use import (
+    LAND_USE_LAYER_NAME,
+    LAND_USE_LAYER_TYPE,
+    LAND_USE_SOURCE,
+    seed_land_use_data,
+)
+
+
+def test_seed_land_use_creates_layer_and_features(db_session):
+    layer = seed_land_use_data(db_session)
+
+    saved_layer = db_session.get(VectorLayer, layer.id)
+
+    assert saved_layer is not None
+    assert saved_layer.name == LAND_USE_LAYER_NAME
+    assert saved_layer.layer_type == LAND_USE_LAYER_TYPE
+    assert saved_layer.source == LAND_USE_SOURCE
+    assert saved_layer.srid == 4326
+    assert saved_layer.properties_schema == {"class": "string"}
+
+    features = list(
+        db_session.scalars(
+            select(VectorFeature).where(VectorFeature.layer_id == saved_layer.id)
+        ).all()
+    )
+
+    assert len(features) == 5
+
+    classes = {feature.properties["class"] for feature in features}
+
+    assert classes == {
+        "forest",
+        "agriculture",
+        "urban",
+        "water",
+        "grassland",
+    }
+
+
+def test_seed_land_use_is_idempotent(db_session):
+    first_layer = seed_land_use_data(db_session)
+    second_layer = seed_land_use_data(db_session)
+
+    assert first_layer.id == second_layer.id
+
+    layers = list(
+        db_session.scalars(
+            select(VectorLayer).where(
+                VectorLayer.name == LAND_USE_LAYER_NAME,
+                VectorLayer.layer_type == LAND_USE_LAYER_TYPE,
+                VectorLayer.source == LAND_USE_SOURCE,
+            )
+        ).all()
+    )
+
+    assert len(layers) == 1
+
+    features = list(
+        db_session.scalars(
+            select(VectorFeature).where(VectorFeature.layer_id == second_layer.id)
+        ).all()
+    )
+
+    assert len(features) == 5
+
+
+def test_seeded_land_use_features_overlap_test_aoi_bounds(db_session):
+    layer = seed_land_use_data(db_session)
+
+    features = list(
+        db_session.scalars(
+            select(VectorFeature).where(VectorFeature.layer_id == layer.id)
+        ).all()
+    )
+
+    assert len(features) > 0
+
+    overlapping_features = [
+        feature
+        for feature in features
+        if feature.properties["class"] in {"forest", "agriculture", "urban", "water"}
+    ]
+
+    assert len(overlapping_features) >= 1
+
+
+def test_seeded_land_use_features_spatially_overlap_test_aoi(db_session):
+    layer = seed_land_use_data(db_session)
+
+    project = Project(name="Seed overlap test project")
+    db_session.add(project)
+    db_session.flush()
+
+    aoi_polygon = Polygon(
+        [
+            (44.50, 40.10),
+            (44.51, 40.10),
+            (44.51, 40.11),
+            (44.50, 40.11),
+            (44.50, 40.10),
+        ]
+    )
+
+    aoi = AOI(
+        project_id=project.id,
+        name="Seed overlap AOI",
+        geometry=from_shape(MultiPolygon([aoi_polygon]), srid=4326),
+        area_m2=1.0,
+        centroid=from_shape(aoi_polygon.centroid, srid=4326),
+        bbox=[44.50, 40.10, 44.51, 40.11],
+    )
+    db_session.add(aoi)
+    db_session.flush()
+
+    overlap_count = db_session.scalar(
+        select(func.count(VectorFeature.id))
+        .where(VectorFeature.layer_id == layer.id)
+        .where(func.ST_Intersects(VectorFeature.geometry, aoi.geometry))
+    )
+
+    assert overlap_count is not None
+    assert overlap_count > 0

--- a/tests/test_seed_land_use.py
+++ b/tests/test_seed_land_use.py
@@ -72,26 +72,6 @@ def test_seed_land_use_is_idempotent(db_session):
     assert len(features) == 5
 
 
-def test_seeded_land_use_features_overlap_test_aoi_bounds(db_session):
-    layer = seed_land_use_data(db_session)
-
-    features = list(
-        db_session.scalars(
-            select(VectorFeature).where(VectorFeature.layer_id == layer.id)
-        ).all()
-    )
-
-    assert len(features) > 0
-
-    overlapping_features = [
-        feature
-        for feature in features
-        if feature.properties["class"] in {"forest", "agriculture", "urban", "water"}
-    ]
-
-    assert len(overlapping_features) >= 1
-
-
 def test_seeded_land_use_features_spatially_overlap_test_aoi(db_session):
     layer = seed_land_use_data(db_session)
 


### PR DESCRIPTION
## Summary

Adds controlled demo land-use seed data for Phase 2 vector analysis work.

This PR introduces a reusable seed function and runnable script that create one `land_use` vector layer with deterministic sample polygon features. Each feature includes a `properties.class` value, and the seed data overlaps the existing test AOI area used by the project.

## Changes

- Added land-use seed module
- Added runnable `scripts/seed_land_use.py`
- Creates one `land_use` vector layer
- Inserts sample polygon features for forest, agriculture, urban, water, and grassland
- Makes the seed operation idempotent
- Added tests for seed creation, idempotency, feature classes, and spatial overlap

## Out of scope

- Feature upload/import API
- Land-use composition analysis
- Analysis result persistence
- Async/background jobs
- Raster analysis

## How tested

- `uv run pytest tests/test_seed_land_use.py`
- `uv run ruff format .`
- `uv run ruff check . --fix`
- `uv run pytest`

Closes #28