### PR TITLE
fix: seed land use transaction

### DIFF
--- a/scripts/seed_land_use.py
+++ b/scripts/seed_land_use.py
@@ -9,7 +9,7 @@ def main() -> None:
         layer = seed_land_use_data(session)
         session.commit()
         print(f"Seeded land-use layer: {layer.id}")
-    except:
+    except Exception:
         session.rollback()
         raise
     finally:

--- a/scripts/seed_land_use.py
+++ b/scripts/seed_land_use.py
@@ -7,7 +7,11 @@ def main() -> None:
 
     try:
         layer = seed_land_use_data(session)
+        session.commit()
         print(f"Seeded land-use layer: {layer.id}")
+    except:
+        session.rollback()
+        raise
     finally:
         session.close()
 

--- a/src/geoinsight_api/db/models/vector_layer.py
+++ b/src/geoinsight_api/db/models/vector_layer.py
@@ -10,14 +10,14 @@ from geoinsight_api.db.base import Base
 class VectorLayer(Base):
     __tablename__ = "vector_layers"
 
-    __table_args__ = (
-        UniqueConstraint(
-            "name",
-            "layer_type",
-            "source",
-            name="uq_vector_layers_name_type_source",
-        ),
-    )
+    # __table_args__ = (
+    #     UniqueConstraint(
+    #         "name",
+    #         "layer_type",
+    #         "source",
+    #         name="uq_vector_layers_name_type_source",
+    #     ),
+    # )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),

--- a/src/geoinsight_api/db/models/vector_layer.py
+++ b/src/geoinsight_api/db/models/vector_layer.py
@@ -10,15 +10,6 @@ from geoinsight_api.db.base import Base
 class VectorLayer(Base):
     __tablename__ = "vector_layers"
 
-    # __table_args__ = (
-    #     UniqueConstraint(
-    #         "name",
-    #         "layer_type",
-    #         "source",
-    #         name="uq_vector_layers_name_type_source",
-    #     ),
-    # )
-
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,

--- a/src/geoinsight_api/db/models/vector_layer.py
+++ b/src/geoinsight_api/db/models/vector_layer.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import DateTime, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import DateTime, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 

--- a/src/geoinsight_api/db/models/vector_layer.py
+++ b/src/geoinsight_api/db/models/vector_layer.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import DateTime, Integer, String, Text, func
+from sqlalchemy import DateTime, Integer, String, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -9,6 +9,10 @@ from geoinsight_api.db.base import Base
 
 class VectorLayer(Base):
     __tablename__ = "vector_layers"
+
+    __table_args__ = UniqueConstraint(
+        "name", "layer_type", "source", name="uq_vector_layer_name_type_source"
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),

--- a/src/geoinsight_api/db/models/vector_layer.py
+++ b/src/geoinsight_api/db/models/vector_layer.py
@@ -10,8 +10,13 @@ from geoinsight_api.db.base import Base
 class VectorLayer(Base):
     __tablename__ = "vector_layers"
 
-    __table_args__ = UniqueConstraint(
-        "name", "layer_type", "source", name="uq_vector_layer_name_type_source"
+    __table_args__ = (
+        UniqueConstraint(
+            "name",
+            "layer_type",
+            "source",
+            name="uq_vector_layers_name_type_source",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/tests/test_seed_land_use.py
+++ b/tests/test_seed_land_use.py
@@ -92,7 +92,7 @@ def test_seed_land_use_is_idempotent(db_session):
         layer_id = layer_list[0].id
 
         features = list(
-            db_session.scalars(
+            new_session.scalars(
                 select(VectorFeature).where(VectorFeature.layer_id == layer_id)
             ).all()
         )

--- a/tests/test_seed_land_use.py
+++ b/tests/test_seed_land_use.py
@@ -6,12 +6,14 @@ from geoinsight_api.db.models.aoi import AOI
 from geoinsight_api.db.models.project import Project
 from geoinsight_api.db.models.vector_feature import VectorFeature
 from geoinsight_api.db.models.vector_layer import VectorLayer
+from geoinsight_api.db.session import SessionLocal
 from geoinsight_api.seeds.land_use import (
     LAND_USE_LAYER_NAME,
     LAND_USE_LAYER_TYPE,
     LAND_USE_SOURCE,
     seed_land_use_data,
 )
+from scripts.seed_land_use import main
 
 
 def test_seed_land_use_creates_layer_and_features(db_session):
@@ -26,11 +28,9 @@ def test_seed_land_use_creates_layer_and_features(db_session):
     assert saved_layer.srid == 4326
     assert saved_layer.properties_schema == {"class": "string"}
 
-    features = list(
-        db_session.scalars(
-            select(VectorFeature).where(VectorFeature.layer_id == saved_layer.id)
-        ).all()
-    )
+    features = db_session.scalars(
+        select(VectorFeature).where(VectorFeature.layer_id == saved_layer.id)
+    ).all()
 
     assert len(features) == 5
 
@@ -43,6 +43,28 @@ def test_seed_land_use_creates_layer_and_features(db_session):
         "water",
         "grassland",
     }
+
+
+def test_seed_land_use_script_persists_data_across_sessions(db_session):
+    main()
+
+    new_session = SessionLocal()
+
+    stored_layer = new_session.scalar(
+        select(VectorLayer).where(
+            VectorLayer.name == LAND_USE_LAYER_NAME,
+            VectorLayer.layer_type == LAND_USE_LAYER_TYPE,
+            VectorLayer.source == LAND_USE_SOURCE,
+        )
+    )
+
+    assert stored_layer is not None
+
+    features = new_session.scalars(
+        select(VectorFeature).where(VectorFeature.layer_id == stored_layer.id)
+    ).all()
+
+    assert len(features) == 5
 
 
 def test_seed_land_use_is_idempotent(db_session):

--- a/tests/test_seed_land_use.py
+++ b/tests/test_seed_land_use.py
@@ -48,50 +48,59 @@ def test_seed_land_use_creates_layer_and_features(db_session):
 def test_seed_land_use_script_persists_data_across_sessions(db_session):
     main()
 
-    new_session = SessionLocal()
+    try:
+        new_session = SessionLocal()
 
-    stored_layer = new_session.scalar(
-        select(VectorLayer).where(
-            VectorLayer.name == LAND_USE_LAYER_NAME,
-            VectorLayer.layer_type == LAND_USE_LAYER_TYPE,
-            VectorLayer.source == LAND_USE_SOURCE,
-        )
-    )
-
-    assert stored_layer is not None
-
-    features = new_session.scalars(
-        select(VectorFeature).where(VectorFeature.layer_id == stored_layer.id)
-    ).all()
-
-    assert len(features) == 5
-
-
-def test_seed_land_use_is_idempotent(db_session):
-    first_layer = seed_land_use_data(db_session)
-    second_layer = seed_land_use_data(db_session)
-
-    assert first_layer.id == second_layer.id
-
-    layers = list(
-        db_session.scalars(
+        stored_layer = new_session.scalar(
             select(VectorLayer).where(
                 VectorLayer.name == LAND_USE_LAYER_NAME,
                 VectorLayer.layer_type == LAND_USE_LAYER_TYPE,
                 VectorLayer.source == LAND_USE_SOURCE,
             )
+        )
+
+        assert stored_layer is not None
+
+        features = new_session.scalars(
+            select(VectorFeature).where(VectorFeature.layer_id == stored_layer.id)
         ).all()
-    )
 
-    assert len(layers) == 1
+        assert len(features) == 5
+    finally:
+        new_session.close()
 
-    features = list(
-        db_session.scalars(
-            select(VectorFeature).where(VectorFeature.layer_id == second_layer.id)
-        ).all()
-    )
 
-    assert len(features) == 5
+def test_seed_land_use_is_idempotent(db_session):
+    main()
+    main()
+
+    try:
+        new_session = SessionLocal()
+
+        layer_list = list(
+            new_session.scalars(
+                select(VectorLayer).where(
+                    VectorLayer.name == LAND_USE_LAYER_NAME,
+                    VectorLayer.layer_type == LAND_USE_LAYER_TYPE,
+                    VectorLayer.source == LAND_USE_SOURCE,
+                )
+            ).all()
+        )
+
+        assert len(layer_list) == 1
+
+        layer_id = layer_list[0].id
+
+        features = list(
+            db_session.scalars(
+                select(VectorFeature).where(VectorFeature.layer_id == layer_id)
+            ).all()
+        )
+
+        assert len(features) == 5
+
+    finally:
+        new_session.close()
 
 
 def test_seeded_land_use_features_spatially_overlap_test_aoi(db_session):


### PR DESCRIPTION
the script previously flushed but did not commit;
it could print success while data was rolled back;
the CLI now owns commit/rollback;
tests verify persistence and idempotency across sessions.